### PR TITLE
Force echo to expand escape sequences

### DIFF
--- a/clean-challenge/mythic-dns01
+++ b/clean-challenge/mythic-dns01
@@ -4,7 +4,7 @@
 
 . "$(dirname "$0")"/../common/mythic-dns01.sh
 
-echo -n "$ARGS" | while read domain filename token; do
+echo -ne "$ARGS" | while read domain filename token; do
     echo " ++ cleaning DNS for $domain"
     call_api DELETE _acme-challenge.$domain $token
 done

--- a/deploy-challenge/mythic-dns01
+++ b/deploy-challenge/mythic-dns01
@@ -4,11 +4,11 @@
 
 . "$(dirname "$0")"/../common/mythic-dns01.sh
 
-echo -n "$ARGS" | while read domain filename token; do
+echo -ne "$ARGS" | while read domain filename token; do
     echo " ++ setting DNS for $domain"
     call_api REPLACE _acme-challenge.$domain $token
 done
-echo -n "$ARGS" | while read domain filename token; do
+echo -ne "$ARGS" | while read domain filename token; do
     echo " ++ waiting DNS for $domain"
     wait_for_dns _acme-challenge.$domain $token
 done


### PR DESCRIPTION
Without the -e option, bash's built-in echo on Ubuntu 18.04 is turning
the \n into a simple 'n'.  Since there's no newline, the loop over
ARGS never executes and tokens never get registered.

Likely a difference in the setting of the xpg_echo shell option
between distributions.