### PR TITLE
Avoid looping forever when hook is called with unchanged_cert

### DIFF
--- a/dehydrated-mythic-dns01.sh
+++ b/dehydrated-mythic-dns01.sh
@@ -5,7 +5,7 @@
 action=$1
 shift
 args=''
-while [ "$1" ]; do args="$args$1 $2 $3\n"; shift 3; done
+while [ -n "$3" ]; do args="$args$1 $2 $3\n"; shift 3; done
 export ARGS="$args"
 
 case $action in


### PR DESCRIPTION
Ubuntu 18.04 has dehydrated 0.6.1 in the default repositories.

When running "dehydrated -c" and there are no certificates to update,
that calls the hook with "unchanged_cert" and 5 additional parameters.

The hook script then hangs (as it will when run when the number of
arguments isn't a multiple of 3), since "$1" is not empty, but "shift
3" fails and leaves the arguments alone.

Avoid this by checking if "$3" is empty instead.